### PR TITLE
Add method selector to disable G keys

### DIFF
--- a/src/devices/keyboard.py
+++ b/src/devices/keyboard.py
@@ -24,6 +24,7 @@ class KeyboardInterface:
     # Following is sent to disable the default G keys mapping
     disableGKeysInterface: int
     disableGKeys: bytes = field(default=b'')
+    disableGKeysUseWrite: bool = field(default=True)
 
 
 @dataclass(frozen=True)
@@ -127,6 +128,7 @@ class Logitech_G710p(KeyboardInterface):
 
     disableGKeys = b'\x09\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00'
     disableGKeysInterface = 1
+    disableGKeysUseWrite = False
 
 @dataclass(frozen=True)
 class Logitech_G815(KeyboardInterface):#

--- a/src/service.py
+++ b/src/service.py
@@ -51,7 +51,10 @@ def _stop(*args):
 async def disableGkeyMapping(keyDev: KeyboardInterface, HIDpath: str):
     logging.debug("Sending sequence to disable G keys")
     with HIDDevice(path=HIDpath) as hdev:
-        hdev.write(keyDev.disableGKeys)
+        if keyDev.disableGKeysUseWrite:
+            hdev.write(keyDev.disableGKeys)
+        else:
+            hdev.send_feature_report(keyDev.disableGKeys)
 
 async def switchProfile(profile):
     global currProfile


### PR DESCRIPTION
Some keyboards require the disableGKeys buffer to be sent via
hidapi_write, but others (e.g. Logitech G710+) need the buffer to be
sent via hidapi_send_feature_report. This commit adds a flag to the
KeyboardInterface class that indicates whether to use the write or the
send_feature_report method, and switches on that accordingly.